### PR TITLE
Improve setup, remove hard-coded DB credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.env
+*.log
+*.tmp

--- a/README.md
+++ b/README.md
@@ -1,7 +1,27 @@
 # License Plate Recognition system:(LRR)
 ##### -license plate recognition system will work with camera to identify the plate number of the car that tries to enter the parking lot, and also check if the car allowed/not allowed to enter by checking the DB of the system.
 
-##### -We have used various approaches to achieve a high accuracy depending on the provided data to detect, segment plate characters, classifiy these characters and check the DB to allow/not allow the car to enter parking lot.
+##### -We have used various approaches to achieve a high accuracy depending on the provided data to detect, segment plate characters, classify these characters and check the DB to allow/not allow the car to enter parking lot.
+
+## Setup
+
+1. Install Python 3 and clone this repository.
+2. Install the required packages:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Configure database credentials using environment variables:
+   - `DB_USER` – database user (default `postgres`)
+   - `DB_PASSWORD` – **required**, the database password
+   - `DB_HOST` – database host (default `127.0.0.1`)
+   - `DB_PORT` – database port (default `5432`)
+   - `DB_NAME` – database name (default `plates`)
+4. Run the API server:
+   ```bash
+   python py_files/API.py
+   ```
+
+The service exposes a `/Process` endpoint that accepts an image file via POST request and returns the recognition result.
 
 
 

--- a/py_files/model.py
+++ b/py_files/model.py
@@ -235,11 +235,15 @@ def get_pn(l):
 
 #################### Check if PlateNumber stored in sys. or Not################
 def check_db(pn):
-    
-     connection = psycopg2.connect(user = "postgres",password = "123456789",
-                                       host = "127.0.0.1",
-                                       port = "5432",
-                                       database = "plates")
+     db_params = {
+         "user": os.getenv("DB_USER", "postgres"),
+         "password": os.getenv("DB_PASSWORD", ""),
+         "host": os.getenv("DB_HOST", "127.0.0.1"),
+         "port": os.getenv("DB_PORT", "5432"),
+         "database": os.getenv("DB_NAME", "plates"),
+     }
+
+     connection = psycopg2.connect(**db_params)
 
      cursor = connection.cursor()
      postgreSQL_select_Query = "select * from plates where license_plate=N{}".format(pn)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+flask
+psycopg2-binary
+numpy
+opencv-python
+scikit-learn
+keras
+pandas
+pillow
+h5py
+matplotlib


### PR DESCRIPTION
## Summary
- use environment variables in `model.py` for DB connection
- add basic Python `.gitignore`
- document setup instructions in README
- specify dependencies in `requirements.txt`

## Testing
- `python -m py_compile py_files/model.py`
- `python -m py_compile py_files/API.py`


------
https://chatgpt.com/codex/tasks/task_e_6844915432588324844de36407a794ef